### PR TITLE
feat(midi): add nodes for easier mapping of grid surfaces 

### DIFF
--- a/crates/components/connections/protocols/midi/device-profiles/profiles/akai-apc-mini/pages.rhai
+++ b/crates/components/connections/protocols/midi/device-profiles/profiles/akai-apc-mini/pages.rhai
@@ -3,6 +3,14 @@ fn generate_page() {
     page = add_buttons(page);
     page += control("Shift").id("button-98").input().note(98);
     page += add_faders();
+    page.grid(8, 8, |x, y| {
+        let button_base = (y - 7).abs() * 8;
+        let button_note = button_base + x;
+
+        let button_id = "button-" + button_note;
+
+        button_id
+    });
 
     page
 }

--- a/crates/components/connections/protocols/midi/device-profiles/profiles/akai-fl-studio-fire/pages.rhai
+++ b/crates/components/connections/protocols/midi/device-profiles/profiles/akai-fl-studio-fire/pages.rhai
@@ -2,15 +2,22 @@ fn generate_page() {
     let page = create_page("Default");
     page = add_buttons(page);
     page += add_knobs();
+    page.grid(4, 16, |x, y| {
+        let pad_index = y * 16 + x;
+
+        let button_id = "pad-" + pad_index;
+
+        button_id
+    });
 
     page
 }
 
 fn add_buttons(page) {
     let pads = create_group("Pads");
-    let pad_index = 0;
     for row_index in range(0, 4) {
         for column_index in range(0, 16) {
+            let pad_index = row_index * 16 + column_index;
             let button_base = 54 + row_index * 16;
             let button_note = button_base + column_index;
 
@@ -22,7 +29,6 @@ fn add_buttons(page) {
                 .note(button_note)
                 .output()
                 .rgb("write_rgb");
-            pad_index += 1;
         }
     }
     let mutes = create_group("Mutes");

--- a/crates/components/connections/protocols/midi/device-profiles/profiles/novation-launchpad/pages.rhai
+++ b/crates/components/connections/protocols/midi/device-profiles/profiles/novation-launchpad/pages.rhai
@@ -1,6 +1,13 @@
 fn generate_page() {
     let page = create_page("Default");
     page = add_buttons(page);
+    page.grid(8, 8, |x, y| {
+        let pad_index = y * 16 + x;
+
+        let button_id = "button-" + pad_index;
+
+        button_id
+    });
 
     page
 }

--- a/crates/components/connections/protocols/midi/device-profiles/src/lib.rs
+++ b/crates/components/connections/protocols/midi/device-profiles/src/lib.rs
@@ -8,7 +8,7 @@ use mizer_util::find_path;
 
 pub use crate::profile::{
     Control, ControlStep, ControlStepVariant, DeviceControl, DeviceProfile, Group,
-    MidiDeviceControl, Page, MidiResolution,
+    MidiDeviceControl, Page, MidiResolution, GridRef,
 };
 use crate::profile_reader::read_profile;
 

--- a/crates/components/connections/protocols/midi/device-profiles/src/profile.rs
+++ b/crates/components/connections/protocols/midi/device-profiles/src/profile.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 use mizer_midi_messages::{Channel, MidiMessage};
-use mizer_util::ErrorCollector;
+use mizer_util::{ErrorCollector, LerpExt};
 
 use crate::scripts::outputs::{Color, OutputEngine, OutputScript};
 
@@ -105,6 +105,13 @@ impl<'a> GridRef<'a> {
 
     pub fn len(&self) -> usize {
         self.0.len()
+    }
+
+    pub fn write(&self, values: &[f64], on_step: Option<u8>, off_step: Option<u8>) -> Vec<MidiMessage> {
+        self.0.iter()
+            .zip(values.iter())
+            .filter_map(|(control, value)| control.send_value(*value, on_step, off_step))
+            .collect()
     }
 }
 
@@ -364,6 +371,52 @@ impl Control {
             },
         }
     }
+
+    pub fn send_value(
+        &self,
+        value: f64,
+        on_step: Option<u8>,
+        off_step: Option<u8>,
+    ) -> Option<MidiMessage> {
+        match self.output {
+            Some(DeviceControl::MidiNote(MidiDeviceControl {
+                                             channel,
+                                             note,
+                                             range,
+                                             ..
+                                         })) => Some(MidiMessage::NoteOn(
+                channel,
+                note,
+                convert_value(value, range, on_step, off_step),
+            )),
+            Some(DeviceControl::MidiCC(MidiDeviceControl {
+                                           channel,
+                                           note,
+                                           range,
+                                           ..
+                                       })) => Some(MidiMessage::ControlChange(
+                channel,
+                note,
+                convert_value(value, range, on_step, off_step),
+            )),
+            _ => None,
+        }
+    }
+}
+
+fn convert_value(value: f64, range: (u16, u16), on_step: Option<u8>, off_step: Option<u8>) -> u8 {
+    if let Some(on_step) = on_step {
+        if value > 0f64 + f64::EPSILON {
+            return on_step;
+        }
+    }
+    if let Some(off_step) = off_step {
+        if value > 0f64 - f64::EPSILON && value < 0f64 + f64::EPSILON {
+            return off_step;
+        }
+    }
+
+    value.linear_extrapolate((0f64, 1f64), (range.0.min(u8::MAX as u16) as u8, range.1.min(u8::MAX as u16) as u8))
 }
 
 #[derive(Debug, Clone)]

--- a/crates/components/connections/protocols/midi/device-profiles/src/profile.rs
+++ b/crates/components/connections/protocols/midi/device-profiles/src/profile.rs
@@ -1,4 +1,5 @@
 use std::convert::TryInto;
+use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -26,18 +27,34 @@ pub struct DeviceProfile {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ControlGrid {
-    rows: usize,
-    columns: usize,
+    rows: u32,
+    columns: u32,
     pub grid: Vec<Control>,
 }
 
 impl ControlGrid {
-    pub fn rows(&self) -> usize {
+    pub fn rows(&self) -> u32 {
         self.rows
     }
-    
-    pub fn cols(&self) -> usize {
+
+    pub fn cols(&self) -> u32 {
         self.columns
+    }
+
+    fn view(&self, min_x: u32, min_y: u32, columns: u32, rows: u32) -> GridRef {
+        let max_x = min_x + columns;
+        let max_y = min_y + rows;
+        GridRef(self.grid.iter()
+            .enumerate()
+            .filter(|(i, _c)| {
+                let i = *i;
+                let x = i as u32 % self.columns;
+                let y = i as u32 / self.columns;
+                
+                (x >= min_x && x < max_x) && (y >= min_y && y < max_y)
+            })
+            .map(|(_i, c)| c)
+            .collect())
     }
 }
 
@@ -64,28 +81,28 @@ pub enum ProfileErrors {
     LayoutLoadingError(String),
 }
 
-impl ProfileErrors {
-    pub fn to_string(&self) -> String {
+impl Display for ProfileErrors {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            ProfileErrors::PagesLoadingError(err) => format!("Pages loading error: {}", err),
+            ProfileErrors::PagesLoadingError(err) => write!(f, "Pages loading error: {}", err),
             ProfileErrors::OutputScriptLoadingError(err) => {
-                format!("Output script loading error: {}", err)
+                write!(f, "Output script loading error: {}", err)
             }
             ProfileErrors::OutputScriptWritingError(err) => {
-                format!("Output script writing error: {}", err)
+                write!(f, "Output script writing error: {}", err)
             }
-            ProfileErrors::LayoutLoadingError(err) => format!("Layout loading error: {}", err),
+            ProfileErrors::LayoutLoadingError(err) => write!(f, "Layout loading error: {}", err),
         }
     }
 }
 
-pub struct GridRef<'a>(&'a [Control]);
+pub struct GridRef<'a>(Vec<&'a Control>);
 
 impl<'a> GridRef<'a> {
     pub fn controls(&self) -> impl Iterator<Item = &Control> {
-        self.0.iter()
+        self.0.iter().copied()
     }
-    
+
     pub fn len(&self) -> usize {
         self.0.len()
     }
@@ -95,12 +112,14 @@ impl DeviceProfile {
     pub fn matches(&self, name: &str) -> bool {
         if let Some(keyword) = &self.keyword {
             name.contains(keyword)
-        }else {
+        } else {
             false
         }
     }
-    
-    pub fn get_grid(&self, page: &str, x: usize, y: usize, columns: usize, rows: usize) -> Option<GridRef> {
+
+    pub fn get_grid(&self, page: &str, x: u32, y: u32, columns: u32, rows: u32) -> Option<GridRef> {
+        tracing::trace!("Getting grid for page {page} at {x}, {y} with {columns} columns and {rows} rows");
+        
         let page = self.pages.iter().find(|p| p.name == page)?;
         let grid = page.grid.as_ref()?;
 
@@ -162,6 +181,7 @@ impl Page {
             name,
             groups: Default::default(),
             controls: Default::default(),
+            grid: Default::default(),
         }
     }
 
@@ -178,6 +198,24 @@ impl Page {
         let grouped_controls = self.groups.iter().flat_map(|g| g.controls.iter());
 
         controls.chain(grouped_controls)
+    }
+
+    pub fn define_grid(
+        &mut self,
+        rows: u32,
+        columns: u32,
+        get_control_id: impl Fn(u32, u32) -> String,
+    ) {
+        let get_id = &get_control_id;
+        let grid = ControlGrid {
+            rows,
+            columns,
+            grid: (0..rows)
+                .flat_map(|y| (0..columns).map(move |x| get_id(x, y)))
+                .filter_map(|id| self.all_controls().find(|c| c.id.as_str() == id).cloned())
+                .collect(),
+        };
+        self.grid = Some(grid);
     }
 }
 
@@ -375,7 +413,7 @@ impl ControlBuilder {
         self.range = Some((from, to));
         self
     }
-    
+
     pub fn resolution(mut self, resolution: MidiResolution) -> Self {
         self.resolution = resolution;
         self

--- a/crates/components/connections/protocols/midi/src/device_state.rs
+++ b/crates/components/connections/protocols/midi/src/device_state.rs
@@ -85,7 +85,7 @@ impl DeviceState {
                 }
             }
         }
-        
+
         values
     }
 

--- a/crates/components/connections/protocols/midi/src/device_state.rs
+++ b/crates/components/connections/protocols/midi/src/device_state.rs
@@ -1,6 +1,6 @@
 use evmap::{ReadHandle, WriteHandle};
 use evmap::shallow_copy::CopyValue;
-use mizer_midi_device_profiles::{DeviceControl, MidiResolution};
+use mizer_midi_device_profiles::{DeviceControl, GridRef, MidiResolution};
 use mizer_midi_messages::{Channel, MidiEvent, MidiMessage};
 use mizer_util::LerpExt;
 
@@ -71,6 +71,22 @@ impl DeviceState {
         };
 
         (state, writer)
+    }
+    
+    pub fn read_grid(&self, grid: &GridRef) -> Vec<f64> {
+        let mut values = Vec::with_capacity(grid.len());
+        for control in grid.controls() {
+            if let Some(input) = control.input.as_ref() {
+                let value = self.read_control_changes(input, None);
+                if let Some((value, _)) = value {
+                    values.push(value);
+                }else {
+                    values.push(Default::default())
+                }
+            }
+        }
+        
+        values
     }
 
     pub fn read_note_changes(&self, channel: Channel, note: u8, last_read: Option<MidiTimestamp>) -> Option<(u8, MidiTimestamp)> {

--- a/crates/runtime/pipeline/node/src/introspection.rs
+++ b/crates/runtime/pipeline/node/src/introspection.rs
@@ -115,6 +115,7 @@ node_type_name! {
         MidiInput,
         MidiInputGrid,
         MidiOutput,
+        MidiOutputGrid,
         Laser,
         IldaFile,
         Gamepad,

--- a/crates/runtime/pipeline/node/src/introspection.rs
+++ b/crates/runtime/pipeline/node/src/introspection.rs
@@ -113,6 +113,7 @@ node_type_name! {
         Envelope,
         StepSequencer,
         MidiInput,
+        MidiInputGrid,
         MidiOutput,
         Laser,
         IldaFile,

--- a/crates/runtime/pipeline/node/src/mocks/mod.rs
+++ b/crates/runtime/pipeline/node/src/mocks/mod.rs
@@ -111,7 +111,7 @@ impl PreviewContext for NodeContextMock {
         self.history.borrow_mut().push(value);
     }
 
-    fn write_multi_preview(&self, data: &[f64]) {}
+    fn write_multi_preview(&self, data: Vec<f64>) {}
 
     fn write_data_preview(&self, _data: StructuredData) {
         todo!()

--- a/crates/runtime/pipeline/node/src/mocks/mod.rs
+++ b/crates/runtime/pipeline/node/src/mocks/mod.rs
@@ -111,6 +111,8 @@ impl PreviewContext for NodeContextMock {
         self.history.borrow_mut().push(value);
     }
 
+    fn write_multi_preview(&self, data: &[f64]) {}
+
     fn write_data_preview(&self, _data: StructuredData) {
         todo!()
     }

--- a/crates/runtime/pipeline/node/src/preview.rs
+++ b/crates/runtime/pipeline/node/src/preview.rs
@@ -21,7 +21,7 @@ pub enum PreviewType {
 
 pub trait PreviewContext {
     fn push_history_value(&self, value: f64);
-    fn write_multi_preview(&self, data: &[f64]);
+    fn write_multi_preview(&self, data: Vec<f64>);
     fn write_data_preview(&self, data: StructuredData);
     fn write_color_preview(&self, data: Color);
     fn write_timecode_preview(&self, timecode: Timecode);

--- a/crates/runtime/pipeline/node/src/preview.rs
+++ b/crates/runtime/pipeline/node/src/preview.rs
@@ -21,6 +21,7 @@ pub enum PreviewType {
 
 pub trait PreviewContext {
     fn push_history_value(&self, value: f64);
+    fn write_multi_preview(&self, data: &[f64]);
     fn write_data_preview(&self, data: StructuredData);
     fn write_color_preview(&self, data: Color);
     fn write_timecode_preview(&self, timecode: Timecode);

--- a/crates/runtime/pipeline/nodes/behaviors/port-operations/src/combine.rs
+++ b/crates/runtime/pipeline/nodes/behaviors/port-operations/src/combine.rs
@@ -40,7 +40,8 @@ impl ProcessingNode for CombineNode {
             .into_iter()
             .map(|value| value.unwrap_or_default())
             .collect::<Vec<_>>();
-        context.write_port(OUTPUT_PORT, values);
+        context.write_port(OUTPUT_PORT, values.clone());
+        context.write_multi_preview(values);
 
         Ok(())
     }

--- a/crates/runtime/pipeline/nodes/behaviors/port-operations/src/conditional.rs
+++ b/crates/runtime/pipeline/nodes/behaviors/port-operations/src/conditional.rs
@@ -94,7 +94,13 @@ impl ProcessingNode for ConditionalNode {
                         context.write_color_preview(value);
                     }
                 }
-                PortType::Multi => transfer_port::<Vec<f64>>(context, is_active),
+                PortType::Multi => {
+                    transfer_port::<Vec<f64>>(context, is_active);
+
+                    if let Some(value) = is_active.then_some(()).and_then(|_| context.read_port(VALUE_INPUT)) {
+                        context.write_multi_preview(value);
+                    }
+                },
                 PortType::Laser => transfer_port::<Vec<LaserFrame>>(context, is_active),
                 PortType::Data => {
                     transfer_port::<StructuredData>(context, is_active);

--- a/crates/runtime/pipeline/nodes/behaviors/port-operations/src/select.rs
+++ b/crates/runtime/pipeline/nodes/behaviors/port-operations/src/select.rs
@@ -88,7 +88,15 @@ impl ProcessingNode for SelectNode {
                         context.write_color_preview(value);
                     }
                 }
-                PortType::Multi => transfer_port::<Vec<f64>>(context, *channel),
+                PortType::Multi => {
+                    transfer_port::<Vec<f64>>(context, *channel);
+                    let ports = context.read_ports::<_, _>(INPUT_PORT);
+                    let value = ports.get(*channel).cloned().flatten();
+
+                    if let Some(value) = value {
+                        context.write_multi_preview(value);
+                    }
+                },
                 PortType::Laser => transfer_port::<Vec<LaserFrame>>(context, *channel),
                 PortType::Data => {
                     transfer_port::<StructuredData>(context, *channel);

--- a/crates/runtime/pipeline/nodes/connections/protocols/midi/src/input_grid.rs
+++ b/crates/runtime/pipeline/nodes/connections/protocols/midi/src/input_grid.rs
@@ -1,0 +1,96 @@
+use serde::{Deserialize, Serialize};
+
+use mizer_node::*;
+use mizer_protocol_midi::*;
+
+use crate::{get_devices, get_pages_and_grid};
+
+const OUTPUT_PORT: &str = "Output";
+
+const DEVICE_SETTING: &str = "Device";
+const PAGE_SETTING: &str = "Page";
+const ROWS_SETTING: &str = "Rows";
+const COLUMNS_SETTING: &str = "Columns";
+const X_SETTING: &str = "X";
+const Y_SETTING: &str = "Y";
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MidiInputGridNode {
+    pub device: String,
+    pub page: String,
+    pub rows: usize,
+    pub columns: usize,
+    pub x: usize,
+    pub y: usize,
+}
+
+impl ConfigurableNode for MidiInputGridNode {
+    fn settings(&self, injector: &Injector) -> Vec<NodeSetting> {
+        let devices = get_devices(injector);
+        let (pages, grid_size) = get_pages_and_grid(injector, &self.device, &self.page);
+        let (max_rows, max_cols) = grid_size.unwrap_or((usize::MAX, usize::MAX));
+
+        vec![
+            setting!(select DEVICE_SETTING, &self.device, devices),
+            setting!(select PAGE_SETTING, &self.page, pages),
+            setting!(ROWS_SETTING, self.rows).max(max_rows).min(0),
+            setting!(COLUMNS_SETTING, self.columns).max(max_cols).min(0),
+            setting!(X_SETTING, self.x).min(0).max(max_cols),
+            setting!(Y_SETTING, self.y).min(0).max(max_rows),
+        ]
+    }
+
+    fn update_setting(&mut self, setting: NodeSetting) -> anyhow::Result<()> {
+        update!(select setting, DEVICE_SETTING, self.device);
+        update!(enum setting, PAGE_SETTING, self.page);
+        update!(uint setting, ROWS_SETTING, self.rows);
+        update!(uint setting, COLUMNS_SETTING, self.columns);
+        update!(uint setting, X_SETTING, self.x);
+        update!(uint setting, Y_SETTING, self.y);
+
+        update_fallback!(setting)
+    }
+}
+
+impl PipelineNode for MidiInputGridNode {
+    fn details(&self) -> NodeDetails {
+        NodeDetails {
+            node_type_name: "MIDI Input Grid".into(),
+            preview_type: PreviewType::Multiple,
+            category: NodeCategory::Connections,
+        }
+    }
+
+    fn list_ports(&self, _injector: &Injector) -> Vec<(PortId, PortMetadata)> {
+        vec![output_port!(OUTPUT_PORT, PortType::Multi)]
+    }
+
+    fn node_type(&self) -> NodeType {
+        NodeType::MidiInputGrid
+    }
+}
+
+impl ProcessingNode for MidiInputGridNode {
+    type State = ();
+
+    fn process(&self, context: &impl NodeContext, _: &mut Self::State) -> anyhow::Result<()> {
+        let Some(connection_manager) = context.try_inject::<MidiConnectionManager>() else {
+            return Ok(());
+        };
+        if let Some(device) = connection_manager.request_device(&self.device)? {
+            let state = device.state();
+
+            if let Some(grid) = device.profile.as_ref().and_then(|profile| profile.get_grid(&self.page, self.x, self.y, self.columns, self.rows)) {
+                let values = state.read_grid(&grid);
+                context.write_multi_preview(&values);
+                context.write_port::<_, port_types::MULTI>(OUTPUT_PORT, values);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn create_state(&self) -> Self::State {
+        Default::default()
+    }
+}

--- a/crates/runtime/pipeline/nodes/connections/protocols/midi/src/input_grid.rs
+++ b/crates/runtime/pipeline/nodes/connections/protocols/midi/src/input_grid.rs
@@ -27,7 +27,7 @@ pub struct MidiInputGridNode {
 impl ConfigurableNode for MidiInputGridNode {
     fn settings(&self, injector: &Injector) -> Vec<NodeSetting> {
         let devices = get_devices(injector);
-        let (pages, grid_size) = get_pages_and_grid(injector, &self.device, &self.page);
+        let (pages, grid_size, _) = get_pages_and_grid(injector, &self.device, &self.page);
         let (max_rows, max_cols) = grid_size.unwrap_or((u32::MAX, u32::MAX));
 
         vec![

--- a/crates/runtime/pipeline/nodes/connections/protocols/midi/src/lib.rs
+++ b/crates/runtime/pipeline/nodes/connections/protocols/midi/src/lib.rs
@@ -9,6 +9,7 @@ use mizer_protocol_midi::{ControlStep, MidiConnectionManager};
 
 pub use self::input::{MidiInputConfig, MidiInputNode};
 pub use self::output::{MidiOutputConfig, MidiOutputNode};
+pub use self::input_grid::{MidiInputGridNode};
 
 mod input;
 mod input_grid;
@@ -148,7 +149,7 @@ fn get_pages_and_grid(
     page_name: &str,
 ) -> (
     Vec<SelectVariant>,
-    Option<(usize, usize)>
+    Option<(u32, u32)>
 ) {
     let connection_manager = injector.get::<MidiConnectionManager>().unwrap();
     let pages = connection_manager
@@ -161,10 +162,11 @@ fn get_pages_and_grid(
     let page = pages.iter().find(|p| p.name == page_name).cloned();
     let pages = pages
         .into_iter()
+        .filter(|p| p.grid.is_some())
         .map(|p| SelectVariant::from(p.name))
         .collect();
-    
-    let grid_size = page.
 
-    (pages, controls, steps)
+    let grid_size = page.and_then(|p| p.grid.as_ref().map(|g| (g.rows(), g.cols())));
+
+    (pages, grid_size)
 }

--- a/crates/runtime/pipeline/nodes/connections/protocols/midi/src/lib.rs
+++ b/crates/runtime/pipeline/nodes/connections/protocols/midi/src/lib.rs
@@ -11,6 +11,7 @@ pub use self::input::{MidiInputConfig, MidiInputNode};
 pub use self::output::{MidiOutputConfig, MidiOutputNode};
 
 mod input;
+mod input_grid;
 mod output;
 
 #[derive(
@@ -137,6 +138,33 @@ fn get_pages_and_controls(
                 })
                 .collect()
         });
+
+    (pages, controls, steps)
+}
+
+fn get_pages_and_grid(
+    injector: &Injector,
+    device: &str,
+    page_name: &str,
+) -> (
+    Vec<SelectVariant>,
+    Option<(usize, usize)>
+) {
+    let connection_manager = injector.get::<MidiConnectionManager>().unwrap();
+    let pages = connection_manager
+        .request_device(device)
+        .ok()
+        .flatten()
+        .and_then(|device| device.profile.clone())
+        .map(|profile| profile.pages)
+        .unwrap_or_default();
+    let page = pages.iter().find(|p| p.name == page_name).cloned();
+    let pages = pages
+        .into_iter()
+        .map(|p| SelectVariant::from(p.name))
+        .collect();
+    
+    let grid_size = page.
 
     (pages, controls, steps)
 }

--- a/crates/runtime/pipeline/nodes/connections/protocols/midi/src/output_grid.rs
+++ b/crates/runtime/pipeline/nodes/connections/protocols/midi/src/output_grid.rs
@@ -1,0 +1,143 @@
+use serde::{Deserialize, Serialize};
+
+use mizer_node::*;
+use mizer_protocol_midi::*;
+
+use crate::{get_devices, get_pages_and_grid};
+
+const INPUT_PORT: &str = "Input";
+
+const DEVICE_SETTING: &str = "Device";
+const PAGE_SETTING: &str = "Page";
+const ROWS_SETTING: &str = "Rows";
+const COLUMNS_SETTING: &str = "Columns";
+const X_SETTING: &str = "X";
+const Y_SETTING: &str = "Y";
+const OFF_STEP_SETTING: &str = "Value Off";
+const ON_STEP_SETTING: &str = "Value On";
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MidiOutputGridNode {
+    pub device: String,
+    pub page: String,
+    pub rows: u32,
+    pub columns: u32,
+    pub x: u32,
+    pub y: u32,
+    #[serde(default)]
+    pub off_step: Option<u8>,
+    #[serde(default)]
+    pub on_step: Option<u8>,
+}
+
+impl ConfigurableNode for MidiOutputGridNode {
+    fn settings(&self, injector: &Injector) -> Vec<NodeSetting> {
+        let devices = get_devices(injector);
+        let (pages, grid_size, mut steps) = get_pages_and_grid(injector, &self.device, &self.page);
+        let (max_rows, max_cols) = grid_size.unwrap_or((u32::MAX, u32::MAX));
+
+        let mut settings = vec![
+            setting!(select DEVICE_SETTING, &self.device, devices),
+            setting!(select PAGE_SETTING, &self.page, pages),
+            setting!(ROWS_SETTING, self.rows).max(max_rows).min(0u32),
+            setting!(COLUMNS_SETTING, self.columns).max(max_cols).min(0u32),
+            setting!(X_SETTING, self.x).min(0u32).max(max_cols),
+            setting!(Y_SETTING, self.y).min(0u32).max(max_rows),
+        ];
+        if let Some(steps) = steps.as_mut() {
+            steps.insert(
+                0,
+                SelectVariant::Item {
+                    value: Default::default(),
+                    label: Default::default(),
+                },
+            );
+        }
+
+        let selected_on_step = self.on_step.map(|value| value.to_string()).unwrap_or_default();
+        let selected_off_step = self.off_step.map(|value| value.to_string()).unwrap_or_default();
+
+        if let Some(steps) = steps {
+            settings.push(setting!(select ON_STEP_SETTING, selected_on_step, steps.clone()));
+            settings.push(setting!(select OFF_STEP_SETTING, selected_off_step, steps));
+        }
+
+        settings
+    }
+
+    fn update_setting(&mut self, setting: NodeSetting) -> anyhow::Result<()> {
+        update!(select setting, DEVICE_SETTING, self.device);
+        update!(select setting, PAGE_SETTING, self.page);
+        update!(uint setting, ROWS_SETTING, self.rows);
+        update!(uint setting, COLUMNS_SETTING, self.columns);
+        update!(uint setting, X_SETTING, self.x);
+        update!(uint setting, Y_SETTING, self.y);
+        update!(select setting, ON_STEP_SETTING, self.on_step, |value: String| {
+                    if value.is_empty() {
+                        Ok(None)
+                    } else {
+                        Some(value.parse::<u8>()).transpose()
+                    }
+                });
+        update!(select setting, OFF_STEP_SETTING, self.off_step, |value: String| {
+                    if value.is_empty() {
+                        Ok(None)
+                    } else {
+                        Some(value.parse::<u8>()).transpose()
+                    }
+                });
+
+        update_fallback!(setting)
+    }
+}
+
+impl PipelineNode for MidiOutputGridNode {
+    fn details(&self) -> NodeDetails {
+        NodeDetails {
+            node_type_name: "MIDI Output Grid".into(),
+            preview_type: PreviewType::Multiple,
+            category: NodeCategory::Connections,
+        }
+    }
+
+    fn list_ports(&self, _injector: &Injector) -> Vec<(PortId, PortMetadata)> {
+        vec![input_port!(INPUT_PORT, PortType::Multi)]
+    }
+
+    fn node_type(&self) -> NodeType {
+        NodeType::MidiOutputGrid
+    }
+}
+
+impl ProcessingNode for MidiOutputGridNode {
+    type State = ();
+
+    fn process(&self, context: &impl NodeContext, _: &mut Self::State) -> anyhow::Result<()> {
+        let Some(connection_manager) = context.try_inject::<MidiConnectionManager>() else {
+            return Ok(());
+        };
+        if let Some(values) = context.multi_input(INPUT_PORT).read_changes() {
+            if let Some(mut device) = connection_manager.request_device(&self.device)? {
+                let messages = if let Some(grid) = device.profile.as_ref().and_then(|profile| profile.get_grid(&self.page, self.x, self.y, self.columns, self.rows)) {
+                    if grid.len() != values.len() {
+                        // TODO: report issue to ui, but we don't have to pad anything because of how the grid implementation works
+                        tracing::warn!("Mismatch between grid size and input values size");
+                    }
+                    grid.write(&values, self.on_step, self.off_step)
+                } else { Default::default() };
+
+                for message in messages {
+                    device.write(message)?;
+                }
+
+                context.write_multi_preview(values);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn create_state(&self) -> Self::State {
+        Default::default()
+    }
+}

--- a/crates/runtime/pipeline/nodes/connections/protocols/midi/src/output_grid.rs
+++ b/crates/runtime/pipeline/nodes/connections/protocols/midi/src/output_grid.rs
@@ -73,19 +73,19 @@ impl ConfigurableNode for MidiOutputGridNode {
         update!(uint setting, X_SETTING, self.x);
         update!(uint setting, Y_SETTING, self.y);
         update!(select setting, ON_STEP_SETTING, self.on_step, |value: String| {
-                    if value.is_empty() {
-                        Ok(None)
-                    } else {
-                        Some(value.parse::<u8>()).transpose()
-                    }
-                });
+            if value.is_empty() {
+                Ok(None)
+            } else {
+                Some(value.parse::<u8>()).transpose()
+            }
+        });
         update!(select setting, OFF_STEP_SETTING, self.off_step, |value: String| {
-                    if value.is_empty() {
-                        Ok(None)
-                    } else {
-                        Some(value.parse::<u8>()).transpose()
-                    }
-                });
+            if value.is_empty() {
+                Ok(None)
+            } else {
+                Some(value.parse::<u8>()).transpose()
+            }
+        });
 
         update_fallback!(setting)
     }

--- a/crates/runtime/pipeline/nodes/src/lib.rs
+++ b/crates/runtime/pipeline/nodes/src/lib.rs
@@ -28,7 +28,7 @@ pub use mizer_input_nodes::{ButtonNode, DialNode, FaderNode, LabelNode};
 pub use mizer_laser_nodes::{IldaFileNode, LaserNode};
 pub use mizer_math_nodes::{MathMode, MathNode};
 pub use mizer_midi_nodes::{
-    MidiInputConfig, MidiInputNode, MidiOutputConfig, MidiOutputNode, NoteMode, MidiInputGridNode,
+    MidiInputConfig, MidiInputNode, MidiOutputConfig, MidiOutputNode, NoteMode, MidiInputGridNode, MidiOutputGridNode,
 };
 pub use mizer_mqtt_nodes::{MqttInputNode, MqttOutputNode};
 pub use mizer_ndi_nodes::{NdiInputNode, NdiOutputNode};
@@ -223,6 +223,7 @@ node_impl! {
     MidiInput(MidiInputNode),
     MidiOutput(MidiOutputNode),
     MidiInputGrid(MidiInputGridNode),
+    MidiOutputGrid(MidiOutputGridNode),
     OpcOutput(OpcOutputNode),
     PixelPattern(PixelPatternGeneratorNode),
     PixelDmx(PixelDmxNode),

--- a/crates/runtime/pipeline/nodes/src/lib.rs
+++ b/crates/runtime/pipeline/nodes/src/lib.rs
@@ -28,7 +28,7 @@ pub use mizer_input_nodes::{ButtonNode, DialNode, FaderNode, LabelNode};
 pub use mizer_laser_nodes::{IldaFileNode, LaserNode};
 pub use mizer_math_nodes::{MathMode, MathNode};
 pub use mizer_midi_nodes::{
-    MidiInputConfig, MidiInputNode, MidiOutputConfig, MidiOutputNode, NoteMode,
+    MidiInputConfig, MidiInputNode, MidiOutputConfig, MidiOutputNode, NoteMode, MidiInputGridNode,
 };
 pub use mizer_mqtt_nodes::{MqttInputNode, MqttOutputNode};
 pub use mizer_ndi_nodes::{NdiInputNode, NdiOutputNode};
@@ -222,6 +222,7 @@ node_impl! {
     Label(LabelNode),
     MidiInput(MidiInputNode),
     MidiOutput(MidiOutputNode),
+    MidiInputGrid(MidiInputGridNode),
     OpcOutput(OpcOutputNode),
     PixelPattern(PixelPatternGeneratorNode),
     PixelDmx(PixelDmxNode),

--- a/crates/runtime/pipeline/src/context.rs
+++ b/crates/runtime/pipeline/src/context.rs
@@ -67,7 +67,7 @@ impl NodePreviewState {
 
     fn push_multi_value(&self, value: Vec<f64>) {
         if let Self::Multi(history) = self {
-            let _stopwatch = stopwatch!("Acquiring write lock", std::time::Duration::from_nanos(100));
+            let _stopwatch = stopwatch!("Acquiring write lock", std::time::Duration::from_micros(10));
             // This usually shouldn't block for long, but while implementing I've noticed a deadlock which I was unable to locate (or reliably reproduce)
             // As this happens in the main loop but is only necessary for the preview in the ui we should never wait too long for this lock
             if let Some(mut guard) = history.try_write_for(std::time::Duration::from_millis(1)) {

--- a/crates/runtime/pipeline/src/context.rs
+++ b/crates/runtime/pipeline/src/context.rs
@@ -51,6 +51,7 @@ pub struct RuntimePortMetadata {
 pub enum NodePreviewState {
     History(Arc<RwLock<ConstGenericRingBuffer<f64, HISTORY_PREVIEW_SIZE>>>),
     Data(Arc<RwLock<Option<StructuredData>>>),
+    Multi(Arc<RwLock<Option<Vec<f64>>>>),
     Color(Arc<RwLock<Option<Color>>>),
     Timecode(Arc<RwLock<Option<Timecode>>>),
     None,
@@ -61,6 +62,13 @@ impl NodePreviewState {
         if let Self::History(history) = self {
             let mut guard = history.write();
             guard.push(value);
+        }
+    }
+
+    fn push_multi_value(&mut self, value: &[f64]) {
+        if let Self::Multi(history) = self {
+            let mut guard = history.write();
+            *guard = Some(value.to_vec());
         }
     }
 
@@ -247,6 +255,11 @@ impl<'a> PreviewContext for PipelineContext<'a> {
     fn push_history_value(&self, value: f64) {
         profiling::scope!("PipelineContext::push_history_value");
         self.preview.borrow_mut().push_history_value(value);
+    }
+
+    fn write_multi_preview(&self, data: &[f64]) {
+        profiling::scope!("PipelineContext::write_multi_preview");
+        todo!()
     }
 
     fn write_data_preview(&self, data: StructuredData) {

--- a/crates/runtime/pipeline/src/preview_ref.rs
+++ b/crates/runtime/pipeline/src/preview_ref.rs
@@ -11,14 +11,15 @@ use parking_lot::RwLock;
 pub enum NodePreviewRef {
     History(Arc<RwLock<ConstGenericRingBuffer<f64, HISTORY_PREVIEW_SIZE>>>),
     Data(Arc<RwLock<Option<StructuredData>>>),
+    Multi(Arc<RwLock<Option<Vec<f64>>>>),
     Color(Arc<RwLock<Option<Color>>>),
     Timecode(Arc<RwLock<Option<Timecode>>>),
 }
 
 impl NodePreviewRef {
     pub fn read_history(&self) -> Option<Vec<f64>> {
-        if let Self::History(pinboard) = self {
-            let guard = pinboard.read();
+        if let Self::History(lock) = self {
+            let guard = lock.read();
 
             Some(guard.to_vec())
         } else {
@@ -26,9 +27,19 @@ impl NodePreviewRef {
         }
     }
 
+    pub fn read_multi(&self) -> Option<Vec<f64>> {
+        if let Self::Multi(lock) = self {
+            let guard = lock.read();
+
+            guard.clone()
+        } else {
+            None
+        }
+    }
+
     pub fn read_data(&self) -> Option<StructuredData> {
-        if let Self::Data(pinboard) = self {
-            let guard = pinboard.read();
+        if let Self::Data(lock) = self {
+            let guard = lock.read();
 
             guard.clone()
         } else {
@@ -37,8 +48,8 @@ impl NodePreviewRef {
     }
 
     pub fn read_color(&self) -> Option<Color> {
-        if let Self::Color(pinboard) = self {
-            let guard = pinboard.read();
+        if let Self::Color(lock) = self {
+            let guard = lock.read();
 
             *guard
         } else {
@@ -47,8 +58,8 @@ impl NodePreviewRef {
     }
 
     pub fn read_timecode(&self) -> Option<Timecode> {
-        if let Self::Timecode(pinboard) = self {
-            let guard = pinboard.read();
+        if let Self::Timecode(lock) = self {
+            let guard = lock.read();
 
             *guard
         } else {

--- a/crates/runtime/pipeline/src/preview_ref.rs
+++ b/crates/runtime/pipeline/src/preview_ref.rs
@@ -6,7 +6,7 @@ use mizer_clock::Timecode;
 use mizer_node::HISTORY_PREVIEW_SIZE;
 use mizer_ports::Color;
 use mizer_util::StructuredData;
-use parking_lot::RwLock;
+use mizer_util::rw_lock::RwLock;
 
 pub enum NodePreviewRef {
     History(Arc<RwLock<ConstGenericRingBuffer<f64, HISTORY_PREVIEW_SIZE>>>),

--- a/crates/runtime/pipeline/src/worker.rs
+++ b/crates/runtime/pipeline/src/worker.rs
@@ -472,11 +472,9 @@ impl PipelineWorker {
         profiling::scope!("PipelineWorker::get_context");
         let context = PipelineContext {
             processing_context: RefCell::new(processing_context),
-            preview: RefCell::new(
-                self.previews
-                    .get_mut(path)
-                    .unwrap_or_else(|| panic!("Missing preview for {path}")),
-            ),
+            preview: self.previews
+                .get(path)
+                .unwrap_or_else(|| panic!("Missing preview for {path}")),
             receivers: self.receivers.get(path),
             senders: self.senders.get(path),
             node_metadata: RefCell::new(node_metadata.entry(path.clone()).or_default()),

--- a/crates/runtime/pipeline/src/worker.rs
+++ b/crates/runtime/pipeline/src/worker.rs
@@ -171,6 +171,10 @@ impl PipelineWorker {
                 self.previews
                     .insert(path.clone(), NodePreviewState::History(Default::default()));
             }
+            PreviewType::Multiple => {
+                self.previews
+                    .insert(path.clone(), NodePreviewState::Multi(Default::default()));
+            }
             PreviewType::Data => {
                 self.previews
                     .insert(path.clone(), NodePreviewState::Data(Default::default()));
@@ -513,6 +517,7 @@ impl PipelineWorker {
             match preview {
                 NodePreviewState::History(buf) => Some(NodePreviewRef::History(buf.clone())),
                 NodePreviewState::Data(buf) => Some(NodePreviewRef::Data(buf.clone())),
+                NodePreviewState::Multi(buf) => Some(NodePreviewRef::Multi(buf.clone())),
                 NodePreviewState::Color(buf) => Some(NodePreviewRef::Color(buf.clone())),
                 NodePreviewState::Timecode(buf) => Some(NodePreviewRef::Timecode(buf.clone())),
                 _ => None,

--- a/crates/ui/ffi/src/apis/node_history.rs
+++ b/crates/ui/ffi/src/apis/node_history.rs
@@ -194,3 +194,15 @@ pub extern "C" fn read_node_timecode_preview(ptr: *const NodeHistory) -> Timecod
 pub extern "C" fn drop_node_history_pointer(ptr: *const NodeHistory) {
     drop_pointer(ptr);
 }
+
+#[no_mangle]
+pub extern "C" fn read_node_multi_preview(ptr: *const NodeHistory) -> Array<f64> {
+    let ffi = Arc::from_pointer(ptr);
+
+    let values = ffi.preview_ref.read_multi().unwrap_or_default();
+
+    std::mem::forget(ffi);
+
+    values.into()
+}
+

--- a/crates/ui/lib/api/plugin/ffi/history.dart
+++ b/crates/ui/lib/api/plugin/ffi/history.dart
@@ -68,6 +68,12 @@ class NodeHistoryPointer extends FFIPointer<NodeHistory> implements TimecodeRead
     return result;
   }
 
+  List<double> readMulti() {
+    var result = this._bindings.read_node_multi_preview(ptr);
+
+    return result.toList();
+  }
+
   @override
   void disposePointer(ffi.Pointer<NodeHistory> ptr) {
     this._bindings.drop_node_history_pointer(ptr);

--- a/crates/ui/lib/views/nodes/widgets/node/preview.dart
+++ b/crates/ui/lib/views/nodes/widgets/node/preview.dart
@@ -7,6 +7,7 @@ import 'package:mizer/views/nodes/widgets/node/preview/color.dart';
 
 import 'preview/data.dart';
 import 'preview/history.dart';
+import 'preview/multi.dart';
 import 'preview/timecode.dart';
 
 const SUPPORTED_PREVIEW_TYPES = [
@@ -14,6 +15,7 @@ const SUPPORTED_PREVIEW_TYPES = [
   Node_NodePreviewType.DATA,
   Node_NodePreviewType.COLOR,
   Node_NodePreviewType.TIMECODE,
+  Node_NodePreviewType.MULTIPLE,
 ];
 
 class NodePreview extends StatelessWidget {
@@ -38,8 +40,12 @@ class NodePreview extends StatelessWidget {
       return DataRenderer(nodesPluginApi, node.path);
     } else if (node.preview == Node_NodePreviewType.COLOR) {
       return ColorRenderer(nodesPluginApi, node.path);
-    } else {
+    } else if (node.preview == Node_NodePreviewType.TIMECODE) {
       return TimecodeRenderer(nodesPluginApi, node.path);
+    } else if (node.preview == Node_NodePreviewType.MULTIPLE) {
+      return MultiRenderer(nodesPluginApi, node.path);
+    } else {
+      return Container();
     }
   }
 }

--- a/crates/ui/lib/views/nodes/widgets/node/preview/multi.dart
+++ b/crates/ui/lib/views/nodes/widgets/node/preview/multi.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+import 'package:mizer/api/plugin/nodes.dart';
+
+class MultiRenderer extends StatefulWidget {
+  final NodesPluginApi pluginApi;
+  final String path;
+
+  MultiRenderer(this.pluginApi, this.path);
+
+  @override
+  State<MultiRenderer> createState() => _MultiRendererState();
+}
+
+class _MultiRendererState extends State<MultiRenderer> {
+  NodeHistoryPointer? pointer;
+
+  _MultiRendererState();
+
+  @override
+  void initState() {
+    super.initState();
+    _updatePointer();
+  }
+
+  @override
+  void didUpdateWidget(MultiRenderer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.path != widget.path) {
+      _updatePointer();
+    }
+  }
+
+  void _updatePointer() {
+    widget.pluginApi.getHistoryPointer(widget.path).then((ptr) {
+      if (pointer != null) {
+        pointer!.dispose();
+        pointer = null;
+      }
+      setState(() {
+        pointer = ptr;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    if (pointer != null) {
+      pointer!.dispose();
+      pointer = null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+        width: 300,
+        height: 200,
+        decoration: BoxDecoration(borderRadius: BorderRadius.circular(2)),
+        clipBehavior: Clip.antiAlias,
+        child: pointer == null ? Container() : MultiPaint(pointer: pointer!));
+  }
+}
+
+class MultiPaint extends StatefulWidget {
+  final NodeHistoryPointer pointer;
+
+  const MultiPaint({required this.pointer, Key? key}) : super(key: key);
+
+  @override
+  State<MultiPaint> createState() => _MultiPaintState();
+}
+
+class _MultiPaintState extends State<MultiPaint> with SingleTickerProviderStateMixin {
+  List<double> values = [];
+  late final Ticker ticker;
+
+  @override
+  void initState() {
+    super.initState();
+    ticker = createTicker((elapsed) => setState(() {
+          if (widget.pointer.isDisposed) {
+            values = [];
+            return;
+          }
+          values = widget.pointer.readMulti();
+        }));
+    ticker.start();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(painter: MultiPainter(values), size: Size(300, 200), willChange: true);
+  }
+
+  @override
+  void dispose() {
+    ticker.dispose();
+    super.dispose();
+  }
+}
+
+class MultiPainter extends CustomPainter {
+  final List<double> values;
+
+  MultiPainter(this.values);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    double thickness = size.width / values.length;
+    Paint paint = Paint()
+      ..color = Color(0xffffffff)
+      ..style = PaintingStyle.fill;
+    Paint backgroundPaint = Paint()
+      ..color = Color(0x11ffffff)
+      ..style = PaintingStyle.stroke;
+
+    for (var i = 0; i < values.length; i++) {
+      var value = values[i];
+      var x = i * thickness;
+      var y = (1 - value) * size.height;
+      canvas.drawRect(Rect.fromLTWH(x, 0, thickness, size.height), backgroundPaint);
+      canvas.drawRect(Rect.fromLTWH(x, y, thickness, size.height), paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant MultiPainter oldDelegate) {
+    return oldDelegate.values != this.values;
+  }
+}

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -27,3 +27,5 @@ mod image;
 mod thread_pinned;
 pub mod tracing;
 mod error_collector;
+
+pub mod rw_lock;

--- a/crates/util/src/rw_lock.rs
+++ b/crates/util/src/rw_lock.rs
@@ -1,0 +1,105 @@
+// We have to use std::sync::RwLock here instead of parking_lot as parking_lot is not safe across dynamic library boundaries.
+// This is because parking_lot uses global state when lock contention occurs which isn't shared to the ffi dylib.
+type InternalRwLock<T> = std::sync::RwLock<T>;
+type InternalRwLockReadGuard<'a, T> = std::sync::RwLockReadGuard<'a, T>;
+type InternalRwLockWriteGuard<'a, T> = std::sync::RwLockWriteGuard<'a, T>;
+
+#[derive(Debug)]
+pub struct RwLock<T> {
+    inner: InternalRwLock<T>,
+    #[cfg(debug_assertions)]
+    id: uuid::Uuid,
+}
+
+impl<T: Default> Default for RwLock<T> {
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
+impl<T> RwLock<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            inner: InternalRwLock::new(value),
+            #[cfg(debug_assertions)]
+            id: uuid::Uuid::new_v4(),
+        }
+    }
+
+    pub fn read(&self) -> RwLockReadGuard<'_, T> {
+        #[cfg(debug_assertions)]
+        tracing::trace!("Trying to acquire read lock for id: {}", self.id);
+        let guard = self.inner.read().unwrap();
+        #[cfg(debug_assertions)]
+        tracing::trace!("Acquired read lock for id: {}", self.id);
+
+        RwLockReadGuard {
+            inner: guard,
+            #[cfg(debug_assertions)]
+            id: self.id,
+        }
+    }
+
+    pub fn write(&self) -> RwLockWriteGuard<'_, T> {
+        #[cfg(debug_assertions)]
+        tracing::trace!("Trying to acquire write lock for id: {}", self.id);
+        let guard = self.inner.write().unwrap();
+        #[cfg(debug_assertions)]
+        tracing::trace!("Acquired write lock for id: {}", self.id);
+
+        RwLockWriteGuard {
+            inner: guard,
+            #[cfg(debug_assertions)]
+            id: self.id,
+        }
+    }
+}
+
+pub struct RwLockReadGuard<'a, T> {
+    inner: InternalRwLockReadGuard<'a, T>,
+    #[cfg(debug_assertions)]
+    id: uuid::Uuid,
+}
+
+impl <'a, T> Drop for RwLockReadGuard<'a, T> {
+    fn drop(&mut self) {
+        #[cfg(debug_assertions)]
+        tracing::trace!("Dropping read lock for id: {}", self.id);
+    }
+}
+
+impl<'a, T> std::ops::Deref for RwLockReadGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.inner
+    }
+}
+
+pub struct RwLockWriteGuard<'a, T> {
+    inner: InternalRwLockWriteGuard<'a, T>,
+    #[cfg(debug_assertions)]
+    id: uuid::Uuid,
+}
+
+impl <'a, T> Drop for RwLockWriteGuard<'a, T> {
+    fn drop(&mut self) {
+        #[cfg(debug_assertions)]
+        tracing::trace!("Dropping write lock for id: {}", self.id);
+    }
+}
+
+impl<'a, T> std::ops::Deref for RwLockWriteGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.inner
+    }
+}
+
+impl<'a, T> std::ops::DerefMut for RwLockWriteGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.inner
+    }
+}
+


### PR DESCRIPTION
Introduces new `MIDI Input Grid` and `MIDI Output Grid` nodes.
They require a configured grid in the midi device profile which can then be read from and written to using `Multiple` Ports.
Grids are currently configured for
* Akai FL Studio Fire
* Novation Launchpad
* Akai APC Mini

This change also implements the `Multiple` preview and fixes an issue with the RwLock used by the node preview in the ui.